### PR TITLE
Basic support for Asynchronous requests

### DIFF
--- a/restlicsharpclient/restliclient/RestClient.cs
+++ b/restlicsharpclient/restliclient/RestClient.cs
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 
+using System;
+
 using restlicsharpclient.restliclient.transport;
 using restlicsharpclient.restliclient.request;
 using restlicsharpclient.restliclient.response;
@@ -42,6 +44,13 @@ namespace restlicsharpclient.restliclient
         {
             transportClient = new DefaultTransportClient();
             this.urlPrefix = urlPrefix;
+        }
+
+        public void RestRequestAsync<TResponse>(Request<TResponse> request, RestliCallback<TResponse> restliCallback) where TResponse : Response
+        {
+            HttpRequest httpRequest = ClientUtil.BuildHttpRequest(request, urlPrefix);
+            TransportCallback transportCallback = new RestliCallbackAdapter<TResponse>(request.responseDecoder, restliCallback);
+            transportClient.RestRequestAsync(httpRequest, transportCallback);
         }
 
         public TResponse RestRequestSync<TResponse>(Request<TResponse> request) where TResponse : Response

--- a/restlicsharpclient/restliclient/RestliCallback.cs
+++ b/restlicsharpclient/restliclient/RestliCallback.cs
@@ -1,0 +1,43 @@
+﻿/*
+   Copyright (c) 2017 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using restlicsharpclient.restliclient.response;
+
+namespace restlicsharpclient.restliclient
+{
+    /// <summary>
+    /// Callback used by the Rest Client in handling the received Response.
+    /// </summary>
+    /// <typeparam name="TResponse">The expected Response type</typeparam>
+    public class RestliCallback<TResponse> where TResponse : Response
+    {
+        public delegate void SuccessHandler(TResponse response);
+
+        public SuccessHandler successHandler;
+
+        public RestliCallback(SuccessHandler successHandler)
+        {
+            this.successHandler = successHandler;
+        }
+
+        public void OnSuccess(TResponse response)
+        {
+            successHandler(response);
+        }
+
+        // TODO: Support OnError(ErrorResponse)
+    }
+}

--- a/restlicsharpclient/restliclient/transport/HttpResponse.cs
+++ b/restlicsharpclient/restliclient/transport/HttpResponse.cs
@@ -14,7 +14,10 @@
    limitations under the License.
 */
 
+using System.Net;
 using System.Collections.Generic;
+
+using restlicsharpclient.restliclient.util;
 
 namespace restlicsharpclient.restliclient.transport
 {
@@ -35,6 +38,24 @@ namespace restlicsharpclient.restliclient.transport
             this.status = status;
             this.headers = headers;
             this.data = data;
+        }
+
+        public HttpResponse(HttpWebResponse httpWebResponse)
+        {
+            byte[] dataBytes = httpWebResponse.GetResponseStream().ReadAllBytes();
+
+            Dictionary<string, string> tempHeaders = new Dictionary<string, string>();
+            WebHeaderCollection responseHeaders = httpWebResponse.Headers;
+            string[] responseHeaderKeys = responseHeaders.AllKeys;
+            foreach (string key in responseHeaderKeys)
+            {
+                tempHeaders.Add(key, responseHeaders.Get(key));
+            }
+
+            // Set all class fields
+            status = (int)httpWebResponse.StatusCode;
+            headers = tempHeaders;
+            data = dataBytes;
         }
     }
 }

--- a/restlicsharpclient/restliclient/transport/RestliCallbackAdapter.cs
+++ b/restlicsharpclient/restliclient/transport/RestliCallbackAdapter.cs
@@ -1,0 +1,47 @@
+﻿/*
+   Copyright (c) 2017 LinkedIn Corp.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using restlicsharpclient.restliclient.response;
+using restlicsharpclient.restliclient.response.decoder;
+
+namespace restlicsharpclient.restliclient.transport
+{
+    /// <summary>
+    /// Implementation of TransportCallback that decodes the received response
+    /// and passes the resulting repsonse into a specified Rest.li callback.
+    /// </summary>
+    /// <typeparam name="TResponse">The type of Response handled</typeparam>
+    class RestliCallbackAdapter<TResponse> : TransportCallback where TResponse : Response
+    {
+        private RestResponseDecoder<TResponse> responseDecoder;
+        private RestliCallback<TResponse> callback;
+
+        public RestliCallbackAdapter(RestResponseDecoder<TResponse> responseDecoder, RestliCallback<TResponse> callback)
+        {
+            this.responseDecoder = responseDecoder;
+            this.callback = callback;
+        }
+
+        public void OnSuccess(HttpResponse httpResponse)
+        {
+            TransportResponse transportResponse = new TransportResponse(httpResponse);
+            TResponse response = responseDecoder.DecodeResponse(transportResponse);
+            callback.OnSuccess(response);
+        }
+
+        // TODO: Support OnError
+    }
+}

--- a/restlicsharpclient/restliclient/transport/TransportCallback.cs
+++ b/restlicsharpclient/restliclient/transport/TransportCallback.cs
@@ -14,18 +14,16 @@
    limitations under the License.
 */
 
-using System;
-
 namespace restlicsharpclient.restliclient.transport
 {
     /// <summary>
-    /// Interface to define how the Rest Client synchronously and asynchronously makes
-    /// HTTP requests and returns HTTP responses.
+    /// Interface defining the callback used by the TransportClient
+    /// after making an asynchronous request.
     /// </summary>
-    public interface TransportClient
+    public interface TransportCallback
     {
-        void RestRequestAsync(HttpRequest httpRequest, TransportCallback transportCallback);
+        void OnSuccess(HttpResponse httpResponse);
 
-        HttpResponse RestRequestSync(HttpRequest httpRequest); 
+        // TODO: Support OnError(HttpRepsonse or ErrorResponse)
     }
 }

--- a/restlicsharpclient/restlicsharpclient.csproj
+++ b/restlicsharpclient/restlicsharpclient.csproj
@@ -62,6 +62,9 @@
     <Compile Include="restliclient\response\EntityResponse.cs" />
     <Compile Include="restliclient\response\Response.cs" />
     <Compile Include="restliclient\RestClient.cs" />
+    <Compile Include="restliclient\RestliCallback.cs" />
+    <Compile Include="restliclient\transport\RestliCallbackAdapter.cs" />
+    <Compile Include="restliclient\transport\TransportCallback.cs" />
     <Compile Include="restliclient\util\RestConstants.cs" />
     <Compile Include="restliclient\transport\DefaultTransportClient.cs" />
     <Compile Include="restliclient\transport\HttpResponse.cs" />


### PR DESCRIPTION
- added new callback interfaces and classes.
- altered `TransportClient` interface (and subclasses) and `RestClient` class to include asynchronous request support
- added new constructor for direct instantiation of `HttpRequest` from `HttpWebRequest`